### PR TITLE
CON-98: Use category=Inventory for cloudtrail-trail-with-global

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -19,7 +19,9 @@ end
 coreo_aws_advisor_alert "cloudtrail-trail-with-global" do
   action :define
   service :cloudtrail
-  level "Warning"
+  category "Inventory"
+  suggested_action "None."
+  level "Information"
   objectives ["trails"]
   audit_objects ["trail_list.include_global_service_events"]
   operators ["=="]


### PR DESCRIPTION
Use category=Inventory for cloudtrail-trail-with-global to avoid audit violation in panel