### PR TITLE
PLA-2468 no-global-trails is hidden from panel

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -34,7 +34,7 @@ coreo_aws_advisor_alert "cloudtrail-trail-with-global" do
 end
 
 coreo_aws_advisor_alert "no-global-trails" do
-  action :nothing
+  action :define
   service :cloudtrail
   category "jsrunner"
   suggested_action "The metadata for this definition is defined in the jsrunner below. Do not put metadata here."


### PR DESCRIPTION
When action is set to nothing alert is removed from ccthis data when execution is completed. I did not find the place where it happens, so it is just hotfix