### PR TITLE
Fix for err of running NGT w/o TWG

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -157,10 +157,12 @@ if (nRegionsWithGlobal == 0) {
             };
         var key = 'selected regions';
         console.log(result['violations'][region]);
-        if (result['violations'][region][region]) {
-            result['violations'][region][region]['violations']['cloudtrail-no-global-trails'] = noGlobalsMetadata;
-        } else {
-            result['violations'][region][region] = noGlobalsAlert;
+        if (result['violations'][region]) {
+          if (result['violations'][region][region]) {
+              result['violations'][region][region]['violations']['cloudtrail-no-global-trails'] = noGlobalsMetadata;
+          } else {
+              result['violations'][region][region] = noGlobalsAlert;
+          }
         }
     });
 }


### PR DESCRIPTION
My last change to this code was a little shortsighted - runs up an error unless there are violations for each region, therefore unsuccessful if running e.g cloudtrail-inventory alone. 

This sorts it out