### PR TITLE
CON-390 Update all audit stack new version cloudcoreojsrunner.

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -143,7 +143,7 @@ coreo_aws_rule_runner_cloudtrail "advise-cloudtrail" do
   regions ${AUDIT_AWS_CLOUDTRAIL_REGIONS}
 end
 
-coreo_aws_rule_runner "advise-cloudtrail-u" do
+coreo_aws_rule_runner_cloudtrail "advise-cloudtrail-u" do
   action :run
   service :cloudtrail
   rules ["cloudtrail-log-file-validating"] if ${AUDIT_AWS_CLOUDTRAIL_ALERT_LIST}.include?("cloudtrail-log-file-validating")

--- a/services/config.rb
+++ b/services/config.rb
@@ -301,6 +301,7 @@ coreo_uni_util_jsrunner "cloudtrail-tags-to-notifiers-array" do
                } ])
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",
+                "cloud account name":"PLAN::cloud_account_name",
                 "violations": COMPOSITE::coreo_uni_util_jsrunner.cloudtrail-aggregate.return}'
   function <<-EOH
 
@@ -343,17 +344,18 @@ const ALLOW_EMPTY = "${AUDIT_AWS_CLOUDTRAIL_ALLOW_EMPTY}";
 const SEND_ON = "${AUDIT_AWS_CLOUDTRAIL_SEND_ON}";
 const SHOWN_NOT_SORTED_VIOLATIONS_COUNTER = false;
 
-const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
+const SETTINGS = { NO_OWNER_EMAIL, OWNER_TAG,
   ALLOW_EMPTY, SEND_ON, SHOWN_NOT_SORTED_VIOLATIONS_COUNTER};
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
-const AuditCLOUDTRAIL = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
-const notifiers = AuditCLOUDTRAIL.getNotifiers();
+const AuditCLOUDTRAIL = new CloudCoreoJSRunner(JSON_INPUT, SETTINGS);
+const letters = AuditCLOUDTRAIL.getLetters();
 
-const JSONReportAfterGeneratingSuppression = AuditCLOUDTRAIL.getJSONForAuditPanel();
+const JSONReportAfterGeneratingSuppression = AuditCLOUDTRAIL.getSortedJSONForAuditPanel();
 coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+coreoExport('report', JSON.stringify(JSONReportAfterGeneratingSuppression['violations']));
 
-callback(notifiers);
+callback(letters);
   EOH
 end
 
@@ -361,6 +363,7 @@ coreo_uni_util_variables "cloudtrail-update-planwide-3" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.cloudtrail-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.cloudtrail-tags-to-notifiers-array.JSONReport'},
+                {'COMPOSITE::coreo_aws_rule_runner_cloudtrail.advise-cloudtrail.report' => 'COMPOSITE::coreo_uni_util_jsrunner.cloudtrail-tags-to-notifiers-array.report'},
                 {'COMPOSITE::coreo_uni_util_variables.cloudtrail-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.cloudtrail-tags-to-notifiers-array.table'}
           ])
 end

--- a/services/config.rb
+++ b/services/config.rb
@@ -293,7 +293,7 @@ coreo_uni_util_jsrunner "cloudtrail-tags-to-notifiers-array" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.8.3"
+                   :version => "*"
                },
                {
                    :name => "js-yaml",

--- a/services/config.rb
+++ b/services/config.rb
@@ -143,7 +143,7 @@ coreo_aws_rule_runner_cloudtrail "advise-cloudtrail" do
   regions ${AUDIT_AWS_CLOUDTRAIL_REGIONS}
 end
 
-coreo_aws_rule_runner_cloudtrail "advise-cloudtrail-u" do
+coreo_aws_rule_runner "advise-cloudtrail-u" do
   action :run
   service :cloudtrail
   rules ["cloudtrail-log-file-validating"] if ${AUDIT_AWS_CLOUDTRAIL_ALERT_LIST}.include?("cloudtrail-log-file-validating")


### PR DESCRIPTION
PLA-3163 Engine does not support empty rules array
CON-287 Audit reports in WebUI and email don't list which AWS account being run on
CON-318 display meta_ attributes on cards
CON-334 add notifiers and jsrunner structures to the AWS config composite
CON-376 Report Emails: Update '# Resources' on cards to '# Cloud Objects'